### PR TITLE
Remove unnecessary postprocess and change tokenizer

### DIFF
--- a/src/llmperf/common.py
+++ b/src/llmperf/common.py
@@ -13,7 +13,7 @@ SUPPORTED_APIS = ["openai", "anthropic", "litellm"]
 
 
 def construct_clients(
-    llm_api: str, num_clients: int, get_token_len: Callable
+    llm_api: str, num_clients: int, get_token_len: Callable[[str], int]
 ) -> List[LLMClient]:
     """Construct LLMClients that will be used to make requests to the LLM API.
 

--- a/src/llmperf/common.py
+++ b/src/llmperf/common.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Callable
 from llmperf.ray_clients.furiosa_client import FuriosaLLMClient
 from llmperf.ray_clients.litellm_client import LiteLLMClient
 from llmperf.ray_clients.openai_chat_completions_client import (
@@ -12,7 +12,9 @@ from llmperf.ray_llm_client import LLMClient
 SUPPORTED_APIS = ["openai", "anthropic", "litellm"]
 
 
-def construct_clients(llm_api: str, num_clients: int) -> List[LLMClient]:
+def construct_clients(
+    llm_api: str, num_clients: int, get_token_len: Callable
+) -> List[LLMClient]:
     """Construct LLMClients that will be used to make requests to the LLM API.
 
     Args:
@@ -24,15 +26,18 @@ def construct_clients(llm_api: str, num_clients: int) -> List[LLMClient]:
 
     """
     if llm_api == "openai":
-        clients = [OpenAIChatCompletionsClient.remote() for _ in range(num_clients)]
+        clients = [
+            OpenAIChatCompletionsClient.remote(get_token_len)
+            for _ in range(num_clients)
+        ]
     elif llm_api == "sagemaker":
         clients = [SageMakerClient.remote() for _ in range(num_clients)]
     elif llm_api == "vertexai":
         clients = [VertexAIClient.remote() for _ in range(num_clients)]
     elif llm_api == "furiosa":
-        clients = [FuriosaLLMClient.remote() for _ in range(num_clients)]
+        clients = [FuriosaLLMClient.remote(get_token_len) for _ in range(num_clients)]
     elif llm_api in SUPPORTED_APIS:
-        clients = [LiteLLMClient.remote() for _ in range(num_clients)]
+        clients = [LiteLLMClient.remote(get_token_len) for _ in range(num_clients)]
     else:
         raise ValueError(
             f"llm_api must be one of the supported LLM APIs: {SUPPORTED_APIS}"

--- a/src/llmperf/datasets/__init__.py
+++ b/src/llmperf/datasets/__init__.py
@@ -7,23 +7,39 @@ from llmperf.datasets.translation import randomly_sample_translation_prompt
 
 
 def randomly_sample_prompt(
-    dataset, prompt_tokens_mean, prompt_tokens_stddev, expect_output_tokens, tokenizer
+    dataset,
+    prompt_tokens_mean,
+    prompt_tokens_stddev,
+    expect_output_tokens,
+    get_token_len,
 ) -> Tuple[str, int]:
     if dataset == "sonnet":
         return randomly_sample_sonnet_lines_prompt(
-            prompt_tokens_mean, prompt_tokens_stddev, expect_output_tokens, tokenizer
+            prompt_tokens_mean,
+            prompt_tokens_stddev,
+            expect_output_tokens,
+            get_token_len,
         )
     elif dataset == "human-eval":
         return randomly_sample_human_eval_prompt(
-            prompt_tokens_mean, prompt_tokens_stddev, expect_output_tokens, tokenizer
+            prompt_tokens_mean,
+            prompt_tokens_stddev,
+            expect_output_tokens,
+            get_token_len,
         )
     elif dataset == "gpqa":
         return randomly_sample_gpqa_prompt(
-            prompt_tokens_mean, prompt_tokens_stddev, expect_output_tokens, tokenizer
+            prompt_tokens_mean,
+            prompt_tokens_stddev,
+            expect_output_tokens,
+            get_token_len,
         )
     elif dataset == "translation":
         return randomly_sample_translation_prompt(
-            prompt_tokens_mean, prompt_tokens_stddev, expect_output_tokens, tokenizer
+            prompt_tokens_mean,
+            prompt_tokens_stddev,
+            expect_output_tokens,
+            get_token_len,
         )
     else:
         raise ValueError(f"Not supported dataset {dataset}")

--- a/src/llmperf/datasets/__init__.py
+++ b/src/llmperf/datasets/__init__.py
@@ -14,32 +14,19 @@ def randomly_sample_prompt(
     get_token_len,
 ) -> Tuple[str, int]:
     if dataset == "sonnet":
-        return randomly_sample_sonnet_lines_prompt(
-            prompt_tokens_mean,
-            prompt_tokens_stddev,
-            expect_output_tokens,
-            get_token_len,
-        )
+        f = randomly_sample_sonnet_lines_prompt
     elif dataset == "human-eval":
-        return randomly_sample_human_eval_prompt(
-            prompt_tokens_mean,
-            prompt_tokens_stddev,
-            expect_output_tokens,
-            get_token_len,
-        )
+        f = randomly_sample_human_eval_prompt
     elif dataset == "gpqa":
-        return randomly_sample_gpqa_prompt(
-            prompt_tokens_mean,
-            prompt_tokens_stddev,
-            expect_output_tokens,
-            get_token_len,
-        )
+        f = randomly_sample_gpqa_prompt
     elif dataset == "translation":
-        return randomly_sample_translation_prompt(
-            prompt_tokens_mean,
-            prompt_tokens_stddev,
-            expect_output_tokens,
-            get_token_len,
-        )
+        f = randomly_sample_translation_prompt
     else:
         raise ValueError(f"Not supported dataset {dataset}")
+
+    return f(
+        prompt_tokens_mean,
+        prompt_tokens_stddev,
+        expect_output_tokens,
+        get_token_len,
+    )

--- a/src/llmperf/datasets/__init__.py
+++ b/src/llmperf/datasets/__init__.py
@@ -25,8 +25,8 @@ def randomly_sample_prompt(
         raise ValueError(f"Not supported dataset {dataset}")
 
     return f(
+        get_token_len,
         prompt_tokens_mean,
         prompt_tokens_stddev,
         expect_output_tokens,
-        get_token_len,
     )

--- a/src/llmperf/datasets/gpqa.py
+++ b/src/llmperf/datasets/gpqa.py
@@ -56,8 +56,8 @@ def randomly_sample_gpqa_prompt(
         prompt = QUERY_TEMPLATE_MULTICHOICE.format(**choices_dict)
         prompts.append(prompt)
 
-        if get_token_len(prompt) < min_prompt_length:
-            min_prompt_length = get_token_len(prompt)
+        if (token_len := get_token_len(prompt)) < min_prompt_length:
+            min_prompt_length = token_len
 
     num_prompt_tokens = sample_random_positive_int(
         prompt_tokens_mean, prompt_tokens_stddev

--- a/src/llmperf/datasets/gpqa.py
+++ b/src/llmperf/datasets/gpqa.py
@@ -1,8 +1,7 @@
 import csv
 import random
 import re
-from typing import Tuple
-from transformers import AutoTokenizer
+from typing import Tuple, Callable
 
 import sys
 
@@ -32,13 +31,8 @@ def randomly_sample_gpqa_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    tokenizer=AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B-Instruct"),
+    get_token_len=Callable,
 ) -> Tuple[str, int]:
-    if tokenizer.pad_token is None:
-        tokenizer.pad_token = tokenizer.eos_token
-
-    get_token_length = lambda text: len(tokenizer.encode(text))
-
     prompts = []
     # FIXME: Use gpqa_other dataset
     min_prompt_length = sys.maxint
@@ -62,8 +56,8 @@ def randomly_sample_gpqa_prompt(
         prompt = QUERY_TEMPLATE_MULTICHOICE.format(**choices_dict)
         prompts.append(prompt)
 
-        if get_token_length(prompt) < min_prompt_length:
-            min_prompt_length = get_token_length(prompt)
+        if get_token_len(prompt) < min_prompt_length:
+            min_prompt_length = get_token_len(prompt)
 
     num_prompt_tokens = sample_random_positive_int(
         prompt_tokens_mean, prompt_tokens_stddev
@@ -74,15 +68,15 @@ def randomly_sample_gpqa_prompt(
         )
 
     prompt = random.choice(prompts)
-    while num_prompt_tokens < get_token_length(prompt):
+    while num_prompt_tokens < get_token_len(prompt):
         prompt = random.choice(prompts)
 
     # padding
     # pad_token_num = 0
-    # remaining_prompt_tokens = num_prompt_tokens - get_token_length(prompt)
+    # remaining_prompt_tokens = num_prompt_tokens - get_token_len(prompt)
     # while remaining_prompt_tokens > 0:
     #     pad_token_num += 1
-    #     remaining_prompt_tokens -= get_token_length(tokenizer.pad_token * pad_token_num)
+    #     remaining_prompt_tokens -= get_token_len(tokenizer.pad_token * pad_token_num)
     # prompt += tokenizer.pad_token * (pad_token_num - 1)
 
-    return [prompt, get_token_length(prompt)]
+    return [prompt, get_token_len(prompt)]

--- a/src/llmperf/datasets/gpqa.py
+++ b/src/llmperf/datasets/gpqa.py
@@ -31,7 +31,7 @@ def randomly_sample_gpqa_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable,
+    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     prompts = []
     # FIXME: Use gpqa_other dataset

--- a/src/llmperf/datasets/gpqa.py
+++ b/src/llmperf/datasets/gpqa.py
@@ -28,10 +28,10 @@ def clean_text(text) -> str:
 
 
 def randomly_sample_gpqa_prompt(
+    get_token_len: Callable[[str], int],
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     prompts = []
     # FIXME: Use gpqa_other dataset

--- a/src/llmperf/datasets/human_eval.py
+++ b/src/llmperf/datasets/human_eval.py
@@ -6,10 +6,10 @@ from llmperf.utils import sample_random_positive_int
 
 
 def randomly_sample_human_eval_prompt(
+    get_token_len: Callable[[str], int],
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     # Instruction from AA's sample code
     prompt = "Read the following function signature and docstring, and fully implement the function described. Your response should only contain the code for this function.\n"

--- a/src/llmperf/datasets/human_eval.py
+++ b/src/llmperf/datasets/human_eval.py
@@ -1,6 +1,5 @@
 import random
-from typing import Tuple
-from transformers import AutoTokenizer
+from typing import Tuple, Callable
 from human_eval.data import read_problems
 
 from llmperf.utils import sample_random_positive_int
@@ -10,13 +9,8 @@ def randomly_sample_human_eval_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    tokenizer=AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B-Instruct"),
+    get_token_len=Callable,
 ) -> Tuple[str, int]:
-    if tokenizer.pad_token is None:
-        tokenizer.pad_token = tokenizer.eos_token
-
-    get_token_length = lambda text: len(tokenizer.encode(text))
-
     # Instruction from AA's sample code
     prompt = "Read the following function signature and docstring, and fully implement the function described. Your response should only contain the code for this function.\n"
 
@@ -24,15 +18,15 @@ def randomly_sample_human_eval_prompt(
     num_prompt_tokens = sample_random_positive_int(
         prompt_tokens_mean, prompt_tokens_stddev
     )
-    while num_prompt_tokens < get_token_length(prompt):
+    while num_prompt_tokens < get_token_len(prompt):
         num_prompt_tokens = sample_random_positive_int(
             prompt_tokens_mean, prompt_tokens_stddev
         )
-    remaining_prompt_tokens = num_prompt_tokens - get_token_length(prompt)
+    remaining_prompt_tokens = num_prompt_tokens - get_token_len(prompt)
     problems = read_problems()
     task_ids = list(problems.keys())
     task_id = random.choice(task_ids)
-    while remaining_prompt_tokens < get_token_length(problems[task_id]["prompt"]):
+    while remaining_prompt_tokens < get_token_len(problems[task_id]["prompt"]):
         task_id = random.choice(task_ids)
     prompt += problems[task_id]["prompt"]
 
@@ -44,4 +38,4 @@ def randomly_sample_human_eval_prompt(
     #     remaining_prompt_tokens -= get_token_length(tokenizer.pad_token * pad_token_num)
     # prompt += tokenizer.pad_token * (pad_token_num - 1)
 
-    return [prompt, get_token_length(prompt)]
+    return [prompt, get_token_len(prompt)]

--- a/src/llmperf/datasets/human_eval.py
+++ b/src/llmperf/datasets/human_eval.py
@@ -9,7 +9,7 @@ def randomly_sample_human_eval_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable,
+    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     # Instruction from AA's sample code
     prompt = "Read the following function signature and docstring, and fully implement the function described. Your response should only contain the code for this function.\n"

--- a/src/llmperf/datasets/sonnet.py
+++ b/src/llmperf/datasets/sonnet.py
@@ -10,7 +10,7 @@ def randomly_sample_sonnet_lines_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable,
+    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     """Generate a prompt that randomly samples lines from a the shakespeare sonnet at sonnet.txt.
 

--- a/src/llmperf/datasets/sonnet.py
+++ b/src/llmperf/datasets/sonnet.py
@@ -7,10 +7,10 @@ from llmperf.utils import sample_random_positive_int
 
 
 def randomly_sample_sonnet_lines_prompt(
+    get_token_len: Callable[[str], int],
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     """Generate a prompt that randomly samples lines from a the shakespeare sonnet at sonnet.txt.
 

--- a/src/llmperf/datasets/translation.py
+++ b/src/llmperf/datasets/translation.py
@@ -3,10 +3,10 @@ from typing import Tuple, Callable
 
 
 def randomly_sample_translation_prompt(
+    get_token_len: Callable[[str], int],
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     # XXX: use this overly simplified condition for now
     if prompt_tokens_mean < 400:

--- a/src/llmperf/datasets/translation.py
+++ b/src/llmperf/datasets/translation.py
@@ -6,7 +6,7 @@ def randomly_sample_translation_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    get_token_len=Callable,
+    get_token_len=Callable[[str], int],
 ) -> Tuple[str, int]:
     # XXX: use this overly simplified condition for now
     if prompt_tokens_mean < 400:

--- a/src/llmperf/datasets/translation.py
+++ b/src/llmperf/datasets/translation.py
@@ -1,27 +1,20 @@
 import random
-from typing import Tuple
-from transformers import AutoTokenizer
+from typing import Tuple, Callable
 
 
 def randomly_sample_translation_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
-    tokenizer=AutoTokenizer.from_pretrained("meta-llama/Llama-3.2-1B-Instruct"),
+    get_token_len=Callable,
 ) -> Tuple[str, int]:
-    if tokenizer.pad_token is None:
-        tokenizer.pad_token = tokenizer.eos_token
-
-    def get_token_length(text):
-        return len(tokenizer.encode(text))
-
     # XXX: use this overly simplified condition for now
     if prompt_tokens_mean < 400:
         prompt = get_prompt_100()
     else:
-        prompt = get_prompt_1000(tokenizer)
+        prompt = get_prompt_1000(get_token_len)
 
-    return [prompt, get_token_length(prompt)]
+    return [prompt, get_token_len(prompt)]
 
 
 def get_prompt_100():
@@ -39,7 +32,7 @@ def get_prompt_100():
     return out
 
 
-def get_prompt_1000(tokenizer):
+def get_prompt_1000(get_token_len):
     """
     Example:
 
@@ -89,7 +82,7 @@ def get_prompt_1000(tokenizer):
     while num_actual_input_sentences < max_num_input_sentences:
         this = f"{num_actual_input_sentences + 1}. {selected_sentences[num_actual_input_sentences]}\n"
         if (
-            len(tokenizer.encode(target_sentence_prompt + this))
+            get_token_len(target_sentence_prompt + this)
             > max_target_sentence_prompt_tokens
         ):
             break

--- a/src/llmperf/ray_clients/furiosa_client.py
+++ b/src/llmperf/ray_clients/furiosa_client.py
@@ -14,6 +14,9 @@ from ray.runtime_env import RuntimeEnv
 class FuriosaLLMClient(LLMClient):
     """Client for FuriosaAI LLM Completion API."""
 
+    def __init__(self, get_token_len):
+        self.get_token_len = get_token_len
+
     def llm_request(self, request_config: RequestConfig) -> Dict[str, Any]:
         """
         FuriosaAI LLM Completion API is compatible with OpenAIChatCompletion API.
@@ -31,11 +34,11 @@ class FuriosaLLMClient(LLMClient):
         os.environ["OPENAI_API_KEY"] = key
 
         # Use greedy search
-        if 'temperature' not in request_config.sampling_params:
-            request_config.sampling_params['temperature'] = 0.0
+        if "temperature" not in request_config.sampling_params:
+            request_config.sampling_params["temperature"] = 0.0
 
         actor = OpenAIChatCompletionsClient.options(
             runtime_env=RuntimeEnv(env_vars=dict(os.environ))
-        ).remote()
+        ).remote(self.get_token_len)
         future = actor.llm_request.remote(request_config)
         return ray.get(future)

--- a/src/llmperf/ray_clients/litellm_client.py
+++ b/src/llmperf/ray_clients/litellm_client.py
@@ -11,6 +11,9 @@ from llmperf import common_metrics
 class LiteLLMClient(LLMClient):
     """Client for LiteLLM Completions API."""
 
+    def __init__(self, get_token_len):
+        self.get_token_len = get_token_len
+
     def llm_request(self, request_config: RequestConfig) -> Dict[str, Any]:
         # litellm package isn't serializable, so we import it within the function
         # to maintain compatibility with ray.

--- a/src/llmperf/ray_clients/openai_chat_completions_client.py
+++ b/src/llmperf/ray_clients/openai_chat_completions_client.py
@@ -64,7 +64,7 @@ class OpenAIChatCompletionsClient(LLMClient):
         if not address.endswith("/"):
             address = address + "/"
         address += "chat/completions"
-        
+
         start_time = time.monotonic()
         most_recent_received_token_time = time.monotonic()
         try:

--- a/src/llmperf/ray_clients/sagemaker_client.py
+++ b/src/llmperf/ray_clients/sagemaker_client.py
@@ -23,6 +23,7 @@ class SageMakerClient(LLMClient):
         self.tokenizer = LlamaTokenizerFast.from_pretrained(
             "hf-internal-testing/llama-tokenizer"
         )
+        self.get_token_len = lambda text: len(self.tokenizer.encode(text))
 
     def llm_request(self, request_config: RequestConfig) -> Dict[str, Any]:
         if not os.environ.get("AWS_ACCESS_KEY_ID"):
@@ -95,7 +96,7 @@ class SageMakerClient(LLMClient):
             resp = json.loads(json_byte)
             total_request_time = time.monotonic() - start_time
             generated_text = resp[0]["generation"]["content"]
-            tokens_received = len(self.tokenizer.encode(generated_text))
+            tokens_received = self.get_token_len(generated_text)
             output_throughput = tokens_received / total_request_time
 
         except Exception as e:

--- a/src/llmperf/ray_clients/vertexai_client.py
+++ b/src/llmperf/ray_clients/vertexai_client.py
@@ -22,6 +22,7 @@ class VertexAIClient(LLMClient):
         self.tokenizer = LlamaTokenizerFast.from_pretrained(
             "hf-internal-testing/llama-tokenizer"
         )
+        self.get_token_len = lambda text: len(self.tokenizer.encode(text))
 
     def llm_request(self, request_config: RequestConfig) -> Dict[str, Any]:
         project_id = os.environ.get("GCLOUD_PROJECT_ID")
@@ -86,7 +87,7 @@ class VertexAIClient(LLMClient):
             # output from the endpoint is in the form:
             # {"predictions": ["Input: ... \nOutput:\n ..."]}
             generated_text = response.json()["predictions"][0].split("\nOutput:\n")[1]
-            tokens_received = len(self.tokenizer.encode(generated_text))
+            tokens_received = self.get_token_len(generated_text)
             ttft = -1
             output_throughput = tokens_received / total_request_time
             time_to_next_token = [

--- a/src/llmperf/ray_llm_client.py
+++ b/src/llmperf/ray_llm_client.py
@@ -7,6 +7,8 @@ from llmperf.models import RequestConfig
 class LLMClient:
     """A client for making requests to a LLM API e.g Anyscale Endpoints."""
 
+    get_token_len = None
+
     @abc.abstractmethod
     def llm_request(
         self, request_config: RequestConfig

--- a/token_benchmark_ray.py
+++ b/token_benchmark_ray.py
@@ -75,7 +75,7 @@ def get_token_throughput_latencies(
     random.seed(11111)
 
     # Use same tokenizer with furiosa-llm serve
-    tokenizer = PreTrainedTokenizerFast.from_pretrained("meta-llama/Meta-Llama-3.1-70B-Instruct")
+    tokenizer = PreTrainedTokenizerFast.from_pretrained(model)
     
     if not additional_sampling_params:
         additional_sampling_params = {}

--- a/token_benchmark_ray.py
+++ b/token_benchmark_ray.py
@@ -74,7 +74,6 @@ def get_token_throughput_latencies(
     """
     random.seed(11111)
 
-    # Use same tokenizer with furiosa-llm serve
     tokenizer = PreTrainedTokenizerFast.from_pretrained(model)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/token_benchmark_ray.py
+++ b/token_benchmark_ray.py
@@ -24,7 +24,7 @@ from llmperf.utils import (
 )
 from tqdm import tqdm
 
-from transformers import PreTrainedTokenizerFast
+from transformers import AutoTokenizer
 
 
 def construct_launcher(scenario, model, clients, additional_sampling_params):
@@ -74,11 +74,11 @@ def get_token_throughput_latencies(
     """
     random.seed(11111)
 
-    tokenizer = PreTrainedTokenizerFast.from_pretrained(model)
+    tokenizer = AutoTokenizer.from_pretrained(model)
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
-    get_token_len = lambda text: len(tokenizer.encode(text))
+    get_token_len = lambda text: len(tokenizer.encode(text, add_special_tokens=False))
 
     if not additional_sampling_params:
         additional_sampling_params = {}


### PR DESCRIPTION
- tokenizer를 `furiosa-llm serve`가 사용하는 tokenizer로 바꿉니다.
- 필요하지 않은 postprocess 과정을 삭제합니다.
- tpot계산에
  - ttft는 제외하고
  - ~~"[DONE]" token은 포함합니다~~  [이 논의](https://furiosa-ai.slack.com/archives/C082FTW2RJA/p1732767707873319?thread_ts=1732757386.923969&cid=C082FTW2RJA)에 따라 `[DONE]` token은 제외했습니다.
- tpot 통계 산출시에 request당 tpot 값들을 모두 하나의 평균값으로 뭉치지 않고, 그대로 노출하도록 수정합니다.