### PR TITLE
Change scenario options to wait_for

### DIFF
--- a/src/llmperf/launcher/__init__.py
+++ b/src/llmperf/launcher/__init__.py
@@ -5,8 +5,6 @@ from llmperf.models import RequestConfig
 from llmperf.ray_llm_client import LLMClient
 from ray.util import ActorPool
 
-SUPPROTED_SCENARIO = ["multi-stream", "single-stream"]
-
 
 class RequestsLauncher:
     """Launch requests from LLMClients to their respective LLM APIs."""

--- a/src/llmperf/launcher/wait_for_all.py
+++ b/src/llmperf/launcher/wait_for_all.py
@@ -5,7 +5,7 @@ from llmperf.launcher import RequestsLauncher
 from llmperf.models import RequestConfig
 
 
-class MultiStreamLauncher(RequestsLauncher):
+class WaitForAllLauncher(RequestsLauncher):
 
     def launch(
         self,

--- a/src/llmperf/launcher/wait_for_any.py
+++ b/src/llmperf/launcher/wait_for_any.py
@@ -5,7 +5,7 @@ from llmperf.launcher import RequestsLauncher
 from llmperf.models import RequestConfig
 
 
-class SingleStreamLauncher(RequestsLauncher):
+class WaitForAnyLauncher(RequestsLauncher):
 
     def launch(
         self,

--- a/token_benchmark_ray.py
+++ b/token_benchmark_ray.py
@@ -14,7 +14,6 @@ from llmperf import common_metrics
 from llmperf.common import SUPPORTED_APIS, construct_clients
 
 from llmperf.datasets import randomly_sample_prompt
-from llmperf.launcher import SUPPROTED_SCENARIO
 
 from llmperf.launcher.wait_for_all import WaitForAllLauncher
 from llmperf.launcher.wait_for_any import WaitForAnyLauncher
@@ -22,7 +21,6 @@ from llmperf.utils import (
     LLMPerfResults,
     sample_random_positive_int,
 )
-from tqdm import tqdm
 
 from transformers import AutoTokenizer
 
@@ -428,7 +426,7 @@ args.add_argument(
     type=str,
     default="all",
     help=(
-        f"The scenario of concurrency requests. Can select from [all, any]"
+        "The number of requests in a bundle that should be completed before sending the next bundle. Can select from [all, any]"
         " (default: %(default)s)"
     ),
 )


### PR DESCRIPTION
기존에 사용하던 `MultiStream`과 `SingleStream`의 naming이 mlperf와의 정의와 달라 혼동을 야기할 수 있습니다. 이 옵션을 `WaitForAll`/`WaitForAny` 옵션으로 수정합니다. [링크](https://furiosa-ai.slack.com/archives/C05G3K8BVG8/p1732850802019699)